### PR TITLE
feat(plan-and-execute): add external dependency research to implementation planning

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
         {
             "name": "ed3d-plan-and-execute",
             "description": "Planning and execution workflows for Claude Code. Based on obra/superpowers.",
-            "version": "1.0.0",
+            "version": "1.2.0",
             "source": "./plugins/ed3d-plan-and-execute",
             "author": {
                 "name": "Ed",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## ed3d-plan-and-execute 1.2.0
+
+Added external dependency research capabilities to implementation planning.
+
+**Changed:**
+- **writing-implementation-plans**: Added tiered external dependency research workflow. Phases involving external libraries now trigger research via `internet-researcher` (for docs/standards) with escalation to `remote-code-researcher` (for source code) when documentation is insufficient.
+
+**New capabilities:**
+- Decision framework for when to research external dependencies
+- Tiered research approach: docs first, source code when needed
+- External dependency findings section in phase output templates
+- Updated per-phase workflow to include research step
+- New rationalizations to prevent skipping external research
+
 ## ed3d-plan-and-execute 1.1.0
 
 Corrects design plan level of detail. These changes were a missed port from the internal plugin marketplace and were intended for 1.0.0. This release represents the plugin "as intended."


### PR DESCRIPTION
## Summary

- Adds tiered external dependency research to `writing-implementation-plans` skill
- Tier 1: `internet-researcher` for docs/standards/API patterns (handles ~80% of cases)
- Tier 2: `remote-code-researcher` for source code when docs are insufficient
- Integrates with existing per-phase workflow alongside `codebase-investigator`

## Test plan

- [ ] Review changes to `writing-implementation-plans/SKILL.md`
- [ ] Verify decision framework makes sense for common scenarios
- [ ] Confirm changelog and marketplace.json version bump to 1.2.0