### PR TITLE
fix: update task tracking references for new Claude Code task system

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
         {
             "name": "ed3d-plan-and-execute",
             "description": "Planning and execution workflows for Claude Code. Based on obra/superpowers.",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "source": "./plugins/ed3d-plan-and-execute",
             "author": {
                 "name": "Ed",
@@ -31,7 +31,7 @@
         {
             "name": "ed3d-house-style",
             "description": "ed3d's house style for software development",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": "./plugins/ed3d-house-style",
             "author": {
                 "name": "Ed",
@@ -63,7 +63,7 @@
         {
             "name": "ed3d-extending-claude",
             "description": "Knowledge skills for extending Claude Code: creating plugins, commands, agents, skills, hooks, and MCP servers",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": "./plugins/ed3d-extending-claude",
             "author": {
                 "name": "Ed",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## ed3d-plan-and-execute 1.5.1
+
+Updates task tracking references for compatibility with new Claude Code task system.
+
+**Changed:**
+- All references to `TodoWrite` now prefer `TaskCreate`/`TaskUpdate`/`TaskList` (the new task tools in Claude Code)
+- Backwards-compatibility notes added for older Claude Code versions that still use `TodoWrite`
+
+## ed3d-extending-claude 1.0.1
+
+Updates task tracking references for compatibility with new Claude Code task system.
+
+**Changed:**
+- Tool tables and examples now reference `TaskCreate`/`TaskUpdate` instead of `TodoWrite`
+- Backwards-compatibility notes added for older Claude Code versions
+
+## ed3d-house-style 1.0.1
+
+Updates task tracking references for compatibility with new Claude Code task system.
+
+**Changed:**
+- Persuasion principles documentation now references `TaskCreate`/`TaskUpdate` instead of `TodoWrite`
+- Backwards-compatibility notes added for older Claude Code versions
+
 ## ed3d-plan-and-execute 1.5.0
 
 Promotes experimental execution workflow to stable.

--- a/plugins/ed3d-extending-claude/.claude-plugin/plugin.json
+++ b/plugins/ed3d-extending-claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "ed3d-extending-claude",
     "description": "Knowledge skills for extending Claude Code: creating plugins, commands, agents, skills, hooks, and MCP servers",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "author": {
         "name": "Ed",
         "email": "ed@ed3d.net"

--- a/plugins/ed3d-extending-claude/skills/creating-an-agent/SKILL.md
+++ b/plugins/ed3d-extending-claude/skills/creating-an-agent/SKILL.md
@@ -99,7 +99,7 @@ Choose tools based on agent responsibilities:
 | Edit | Modifying existing files |
 | Write | Creating new files |
 | Bash | Running commands, git, tests |
-| TodoWrite | Tracking multi-step workflows |
+| TaskCreate/TaskUpdate | Tracking multi-step workflows (TodoWrite in older versions) |
 | Task | Spawning sub-agents |
 | WebFetch/WebSearch | Research tasks |
 
@@ -281,7 +281,7 @@ You are a research specialist gathering and synthesizing information.
 ---
 name: task-implementor
 description: Use when implementing specific tasks from plans - writes code, runs tests, commits changes following TDD workflow
-tools: Read, Edit, Write, Bash, Grep, Glob, TodoWrite
+tools: Read, Edit, Write, Bash, Grep, Glob, TaskCreate, TaskUpdate, TaskList
 model: sonnet
 ---
 

--- a/plugins/ed3d-extending-claude/skills/writing-claude-directives/SKILL.md
+++ b/plugins/ed3d-extending-claude/skills/writing-claude-directives/SKILL.md
@@ -86,7 +86,7 @@ Use structure to make compliance the path of least resistance:
 | Pattern | Example |
 |---------|---------|
 | Workflow steps | Numbered steps with verification gates |
-| TodoWrite tracking | Checklists without tracking = skipped steps |
+| Task tracking (TaskCreate/TaskUpdate) | Checklists without tracking = skipped steps (TodoWrite in older versions) |
 | Forced commitment | "Announce: I'm using [skill]" |
 | Explicit blocking | "If X happens, stop and do Y instead" |
 

--- a/plugins/ed3d-extending-claude/skills/writing-skills/SKILL.md
+++ b/plugins/ed3d-extending-claude/skills/writing-skills/SKILL.md
@@ -138,7 +138,7 @@ Run pressure scenario WITHOUT skill:
 
 ## Skill Creation Checklist
 
-**IMPORTANT:** Use TodoWrite for each item.
+**IMPORTANT:** Use TaskCreate to track each item (or TodoWrite in older Claude Code versions).
 
 **RED Phase:**
 - [ ] Create pressure scenarios (3+ combined pressures for discipline skills)

--- a/plugins/ed3d-house-style/.claude-plugin/plugin.json
+++ b/plugins/ed3d-house-style/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "ed3d-house-style",
     "description": "Ed's stylistic particulars for writing code and English.",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "author": {
         "name": "Ed",
         "email": "ed@ed3d.net"

--- a/plugins/ed3d-house-style/_docs/persuasion-principles.md
+++ b/plugins/ed3d-house-style/_docs/persuasion-principles.md
@@ -33,7 +33,7 @@ LLMs respond to the same persuasion principles as humans. Understanding this psy
 **How it works in skills:**
 - Require announcements: "Announce skill usage"
 - Force explicit choices: "Choose A, B, or C"
-- Use tracking: TodoWrite for checklists
+- Use tracking: TaskCreate/TaskUpdate for checklists (TodoWrite in older versions)
 
 **When to use:**
 - Ensuring skills are actually followed
@@ -80,8 +80,8 @@ LLMs respond to the same persuasion principles as humans. Understanding this psy
 
 **Example:**
 ```markdown
-✅ Checklists without TodoWrite tracking = steps get skipped. Every time.
-❌ Some people find TodoWrite helpful for checklists.
+✅ Checklists without task tracking = steps get skipped. Every time.
+❌ Some people find task tracking helpful for checklists.
 ```
 
 ### 5. Unity

--- a/plugins/ed3d-plan-and-execute/.claude-plugin/plugin.json
+++ b/plugins/ed3d-plan-and-execute/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "ed3d-plan-and-execute",
     "description": "Planning and execution workflows for Claude Code. Based on obra/superpowers.",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "author": {
         "name": "Ed",
         "email": "ed@ed3d.net"

--- a/plugins/ed3d-plan-and-execute/skills/brainstorming/SKILL.md
+++ b/plugins/ed3d-plan-and-execute/skills/brainstorming/SKILL.md
@@ -23,15 +23,15 @@ Transform rough ideas into fully-formed designs through structured questioning a
 
 ## The Process
 
-**REQUIRED: Create TodoWrite tracker at start**
+**REQUIRED: Create task tracker at start**
 
-Use TodoWrite to create todos for each phase:
+Use TaskCreate to create todos for each phase (or TodoWrite in older Claude Code versions):
 
 - Phase 1: Understanding (purpose, constraints, criteria gathered)
 - Phase 2: Exploration (2-3 approaches proposed and evaluated)
 - Phase 3: Design Presentation (design validated in sections)
 
-Mark each phase as in_progress when working on it, completed when finished.
+Use TaskUpdate to mark each phase as in_progress when working on it, completed when finished (or TodoWrite in older versions).
 
 ## Research Agents
 
@@ -125,7 +125,7 @@ Then use WebFetch to read the official docs
    - Review investigator's findings before proceeding
 
 2. **Then gather requirements:**
-   - Mark Phase 1 as in_progress in TodoWrite
+   - Use TaskUpdate to mark Phase 1 as in_progress
    - Ask ONE question at a time to refine the idea
    - **Use AskUserQuestion tool** when you have multiple choice options
    - **Use agents** when you need to verify technical information
@@ -198,7 +198,7 @@ No reasonably secure system would do either options #2 or #3. The way this quest
    - Review research findings before proposing
 
 2. **Then propose approaches:**
-   - Mark Phase 2 as in_progress in TodoWrite
+   - Use TaskUpdate to mark Phase 2 as in_progress
    - Propose 2-3 different approaches based on research
    - At least one approach should follow codebase patterns (if they exist)
    - For each: Core architecture, trade-offs, complexity assessment
@@ -221,7 +221,7 @@ Options:
 
 ## Phase 3: Design Presentation
 
-- Mark Phase 3 as in_progress in TodoWrite
+- Use TaskUpdate to mark Phase 3 as in_progress
 - Present in 200-300 word sections
 - Cover: Architecture, components, data flow, error handling, testing
 - **Use research agents if you need to verify technical details during presentation**
@@ -319,7 +319,7 @@ These are violations of the skill requirements:
 | "Idea is simple, can skip exploring alternatives" | Always propose 2-3 approaches. Comparison reveals issues. |
 | "Partner knows what they want, can skip questions" | Questions reveal hidden constraints. Always ask. |
 | "I'll present whole design at once for efficiency" | Incremental validation catches problems early. |
-| "Checklist is just a suggestion" | Create TodoWrite todos. Track progress properly. |
+| "Checklist is just a suggestion" | Create task todos with TaskCreate. Track progress properly. |
 | "I can research this quickly myself" | Use agents or web tools. You'll hallucinate or consume excessive context. |
 | "Agent didn't find it on first try, must not exist" | Be persistent. Refine query and try again. |
 | "Partner said yes, done with brainstorming" | Design is in conversation. Next step is documentation. |
@@ -342,7 +342,7 @@ These are violations of the skill requirements:
 | **YAGNI ruthlessly** | Remove unnecessary features from all designs |
 | **Explore alternatives** | YOU MUST propose 2-3 approaches before settling |
 | **Incremental validation** | Present design in sections, validate each - never all at once |
-| **TodoWrite tracking** | YOU MUST create TodoWrite todos at start, update as you progress |
+| **Task tracking** | YOU MUST create task todos at start with TaskCreate, update with TaskUpdate as you progress (or TodoWrite in older versions) |
 | **Flexible progression** | Go backward when needed - flexibility > rigidity |
 | **Internet research matters** | Use research agents or web tools for external knowledge and current information |
 

--- a/plugins/ed3d-plan-and-execute/skills/executing-an-implementation-plan/SKILL.md
+++ b/plugins/ed3d-plan-and-execute/skills/executing-an-implementation-plan/SKILL.md
@@ -68,7 +68,7 @@ head -10 [plan-directory]/phase_01.md
 grep -E "START_TASK_|START_SUBCOMPONENT_" [plan-directory]/phase_01.md
 ```
 
-The header includes the title (`# [Phase Title]`) and `**Goal:**` line. Extract the title for the TodoWrite entry.
+The header includes the title (`# [Phase Title]`) and `**Goal:**` line. Extract the title for the task entry.
 
 The grep output shows the task structure, e.g.:
 ```
@@ -84,9 +84,9 @@ Examples of headers you might see:
 - `# Document Infrastructure Implementation Plan` — Phase 1 implied
 - `# Phase 4: Link Resolution` — Phase number explicit
 
-### 2. Create Phase-Level TodoWrite
+### 2. Create Phase-Level Task List
 
-Create TodoWrite with **three entries per phase**. Include the title from the header:
+Use TaskCreate to create **three task entries per phase** (or TodoWrite in older Claude Code versions). Include the title from the header:
 
 ```
 - [ ] Phase 1a: Read /absolute/path/to/phase_01.md — Document Infrastructure Implementation Plan
@@ -98,7 +98,7 @@ Create TodoWrite with **three entries per phase**. Include the title from the he
 ...
 ```
 
-**Why absolute paths in TodoWrite:** After compaction, context may be summarized. The absolute path in the todo item ensures you always know exactly which file to read.
+**Why absolute paths in task entries:** After compaction, context may be summarized. The absolute path in the task entry ensures you always know exactly which file to read.
 
 **Why include the title:** Gives visibility into what each phase covers without loading full content.
 
@@ -327,7 +327,7 @@ You: I'm using the `executing-an-implementation-plan` skill.
 [Discover phases: phase_01.md, phase_02.md, phase_03.md]
 [Read first 3 lines of each to get titles]
 
-[Create TodoWrite:]
+[Create tasks with TaskCreate:]
 - [ ] Phase 1a: Read /path/to/phase_01.md — Project Setup
 - [ ] Phase 1b: Execute tasks
 - [ ] Phase 1c: Code review

--- a/plugins/ed3d-plan-and-execute/skills/starting-a-design-plan/SKILL.md
+++ b/plugins/ed3d-plan-and-execute/skills/starting-a-design-plan/SKILL.md
@@ -26,9 +26,9 @@ Orchestrate the complete design workflow from initial idea to implementation-rea
 
 ## The Process
 
-**REQUIRED: Create TodoWrite tracker at start**
+**REQUIRED: Create task tracker at start**
 
-Use TodoWrite to create todos for each phase:
+Use TaskCreate to create todos for each phase (or TodoWrite in older Claude Code versions):
 
 - Phase 1: Context Gathering (initial information collected)
 - Phase 2: Clarification (requirements disambiguated)
@@ -37,13 +37,13 @@ Use TodoWrite to create todos for each phase:
 - Phase 5: Design Documentation (design written to docs/design-plans/)
 - Phase 6: Planning Handoff (implementation plan offered/created)
 
-Mark each phase as in_progress when working on it, completed when finished.
+Use TaskUpdate to mark each phase as in_progress when working on it, completed when finished (or TodoWrite in older versions).
 
 ### Phase 1: Context Gathering
 
 **Never skip this phase.** Even if the user provides detailed information, ask for anything missing.
 
-Mark Phase 1 as in_progress in TodoWrite.
+Use TaskUpdate to mark Phase 1 as in_progress.
 
 **Ask the user to provide (freeform, not AskUserQuestion):**
 
@@ -78,7 +78,7 @@ Mark Phase 1 as completed when you have initial context.
 
 ### Phase 2: Clarification
 
-Mark Phase 2 as in_progress in TodoWrite.
+Use TaskUpdate to mark Phase 2 as in_progress.
 
 **REQUIRED SUB-SKILL:** Use ed3d-plan-and-execute:asking-clarifying-questions
 
@@ -99,7 +99,7 @@ Mark Phase 2 as completed when requirements are disambiguated.
 
 Before brainstorming the *how*, lock in the *what*. Brainstorming explores texture and approach — it assumes the goal is already clear.
 
-Mark Phase 3 as in_progress in TodoWrite.
+Use TaskUpdate to mark Phase 3 as in_progress.
 
 **Synthesize the Definition of Done from context gathered so far:**
 
@@ -170,7 +170,7 @@ Mark Phase 3 as completed when user confirms the Definition of Done AND the file
 
 With clear understanding from Phases 1-3, explore design alternatives and validate the approach.
 
-Mark Phase 4 as in_progress in TodoWrite.
+Use TaskUpdate to mark Phase 4 as in_progress.
 
 **REQUIRED SUB-SKILL:** Use ed3d-plan-and-execute:brainstorming
 
@@ -196,7 +196,7 @@ Mark Phase 4 as completed when design is validated.
 
 Append the validated design to the document created in Phase 3.
 
-Mark Phase 5 as in_progress in TodoWrite.
+Use TaskUpdate to mark Phase 5 as in_progress.
 
 **REQUIRED SUB-SKILL:** Use ed3d-plan-and-execute:writing-design-plans
 
@@ -224,7 +224,7 @@ Mark Phase 5 as completed when design document is committed.
 
 After design is documented, guide user to create implementation plan in fresh context.
 
-Mark Phase 6 as in_progress in TodoWrite.
+Use TaskUpdate to mark Phase 6 as in_progress.
 
 **Do NOT create implementation plan directly.** The user needs to /clear context first.
 
@@ -296,5 +296,5 @@ You can and should go backward when:
 | **Clarify before ideating** | Phase 2 prevents building the wrong thing |
 | **Lock in the goal before exploring** | Phase 3 confirms what "done" means before brainstorming the how |
 | **All brains in skills** | This skill orchestrates; sub-skills contain domain expertise |
-| **TodoWrite tracking** | YOU MUST create and update todos for all phases |
+| **Task tracking** | YOU MUST create todos with TaskCreate and update with TaskUpdate for all phases (or TodoWrite in older versions) |
 | **Flexible progression** | Go backward when needed to fill gaps |

--- a/plugins/ed3d-plan-and-execute/skills/using-plan-and-execute/SKILL.md
+++ b/plugins/ed3d-plan-and-execute/skills/using-plan-and-execute/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-plan-and-execute
-description: Use when starting any conversation - establishes mandatory workflows for finding and using skills, including using Read tool before announcing usage, following brainstorming before coding, and creating TodoWrite todos for checklists
+description: Use when starting any conversation - establishes mandatory workflows for finding and using skills, including using Read tool before announcing usage, following brainstorming before coding, and creating task todos for checklists
 ---
 
 <EXTREMELY-IMPORTANT>
@@ -48,7 +48,7 @@ If a skill for your task exists, you must use it or you will fail at your task.
 
 ## Skills with Checklists
 
-If a skill has a checklist, YOU MUST create TodoWrite todos for EACH item.
+If a skill has a checklist, YOU MUST create task todos for EACH item using TaskCreate (or TodoWrite in older Claude Code versions).
 
 **Don't:**
 - Work through checklist mentally
@@ -56,7 +56,7 @@ If a skill has a checklist, YOU MUST create TodoWrite todos for EACH item.
 - Batch multiple items into one todo
 - Mark complete without doing them
 
-**Why:** Checklists without TodoWrite tracking = steps get skipped. Every time. The overhead of TodoWrite is tiny compared to the cost of missing steps.
+**Why:** Checklists without task tracking = steps get skipped. Every time. The overhead of task management is tiny compared to the cost of missing steps.
 
 ## Announcing Skill Usage
 
@@ -94,6 +94,6 @@ Your human partner's specific instructions describe WHAT to do, not HOW.
 3. Announce you're using it
 4. Follow what it says
 
-**Skill has checklist?** TodoWrite for every item.
+**Skill has checklist?** TaskCreate for every item (or TodoWrite in older versions).
 
 **Finding a relevant skill = mandatory to read and use it. Not optional.**

--- a/plugins/ed3d-plan-and-execute/skills/writing-implementation-plans/SKILL.md
+++ b/plugins/ed3d-plan-and-execute/skills/writing-implementation-plans/SKILL.md
@@ -327,9 +327,9 @@ When tasks form a logical subcomponent (e.g., types → implementation → tests
 
 **Workflow depends on review mode selected above.**
 
-**Step 0: Create TodoWrite tracker**
+**Step 0: Create task tracker**
 
-After verifying scope (≤8 phases), create a TodoWrite todo list with one item per phase:
+After verifying scope (≤8 phases), use TaskCreate to create a todo list with one item per phase (or TodoWrite in older Claude Code versions):
 
 ```markdown
 - [ ] Phase 1: [Phase Name]
@@ -338,7 +338,7 @@ After verifying scope (≤8 phases), create a TodoWrite todo list with one item 
 ...
 ```
 
-Mark each phase as in_progress when working on it, completed when written to disk.
+Use TaskUpdate to mark each phase as in_progress when working on it, completed when written to disk (or TodoWrite in older versions).
 
 ---
 
@@ -346,7 +346,7 @@ Mark each phase as in_progress when working on it, completed when written to dis
 
 **Workflow for EACH phase:**
 
-1. **Mark phase as in_progress** in TodoWrite
+1. **Use TaskUpdate to mark phase as in_progress**
 2. **Read design phase** from original plan
 3. **Verify codebase state** for files mentioned in this phase:
    - Dispatch codebase-investigator with design assumptions for this phase
@@ -410,7 +410,7 @@ Mark each phase as in_progress when working on it, completed when written to dis
 7. **If approved:**
    - Write to `docs/implementation-plans/YYYY-MM-DD-<feature-name>/phase_##.md`
    - Plan document contains ONLY the implementation tasks (no verification findings)
-   - Mark phase as completed in TodoWrite, continue to next phase
+   - Use TaskUpdate to mark phase as completed, continue to next phase
 8. **If needs revision:** Keep as in_progress, revise based on feedback, present again
 
 ---
@@ -419,7 +419,7 @@ Mark each phase as in_progress when working on it, completed when written to dis
 
 **Workflow for EACH phase:**
 
-1. **Mark phase as in_progress** in TodoWrite
+1. **Use TaskUpdate to mark phase as in_progress**
 2. **Read design phase** from original plan
 3. **Verify codebase state** for files mentioned in this phase:
    - Dispatch codebase-investigator with design assumptions for this phase
@@ -429,7 +429,7 @@ Mark each phase as in_progress when working on it, completed when written to dis
    - Escalate to remote-code-researcher if docs are insufficient
 5. **Write implementation tasks** for this phase based on actual codebase state and external research
 6. **Write directly to disk** at `docs/implementation-plans/YYYY-MM-DD-<feature-name>/phase_##.md`
-7. **Mark phase as completed** in TodoWrite, continue to next phase
+7. **Use TaskUpdate to mark phase as completed**, continue to next phase
 
 **Do NOT emit phase content to the user before writing.** This conserves tokens.
 
@@ -619,17 +619,17 @@ Which approach should I take?
 **Before starting:**
 - [ ] Count phases - refuse if >8
 - [ ] Ask user for review mode (batch vs interactive)
-- [ ] Create TodoWrite with all phases
+- [ ] Create task list with TaskCreate for all phases
 
 **For each phase:**
-- [ ] Mark phase as in_progress in TodoWrite
+- [ ] Use TaskUpdate to mark phase as in_progress
 - [ ] Dispatch codebase-investigator with design assumptions for this phase
 - [ ] **If phase involves external dependencies:** Research them (internet-researcher first, escalate to remote-code-researcher if needed)
 - [ ] Write complete tasks with exact paths and code based on investigator and research findings
 - [ ] **If interactive mode:** Output complete phase plan, use AskUserQuestion for approval
 - [ ] **If batch mode:** Skip user presentation, write directly to disk
 - [ ] Write plan to `docs/implementation-plans/YYYY-MM-DD-<feature-name>/phase_##.md`
-- [ ] Mark phase as completed in TodoWrite
+- [ ] Use TaskUpdate to mark phase as completed
 
 **For each task:**
 - [ ] Exact file paths with line numbers for modifications


### PR DESCRIPTION
## Summary

- Updates all `TodoWrite` references to prefer `TaskCreate`/`TaskUpdate`/`TaskList` (the new task tools in Claude Code)
- Adds backwards-compatibility notes for older Claude Code versions that still use `TodoWrite`
- Bumps versions for affected plugins

## Affected plugins

| Plugin | Version |
|--------|---------|
| ed3d-plan-and-execute | 1.5.0 → 1.5.1 |
| ed3d-extending-claude | 1.0.0 → 1.0.1 |
| ed3d-house-style | 1.0.0 → 1.0.1 |

## Test plan

- [ ] Verify skills load correctly in newer Claude Code (with TaskCreate/TaskUpdate)
- [ ] Verify backwards-compat notes are clear for older Claude Code instances