### PR TITLE
feat(plan-and-execute): add granular task tracking for compaction resilience

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
         {
             "name": "ed3d-plan-and-execute",
             "description": "Planning and execution workflows for Claude Code. Based on obra/superpowers.",
-            "version": "1.5.1",
+            "version": "1.6.0",
             "source": "./plugins/ed3d-plan-and-execute",
             "author": {
                 "name": "Ed",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## ed3d-plan-and-execute 1.6.0
+
+Adds granular task tracking to implementation plan writing to survive context compaction.
+
+**New in `writing-implementation-plans`:**
+- **Granular per-phase tasks:** Instead of one task per phase, now creates sub-tasks for each step:
+  - Phase NA: Read `<!-- START_PHASE_N -->` section from design plan
+  - Phase NB: Dispatch codebase-investigator to verify current state
+  - Phase NC: Research external dependencies (if applicable)
+  - Phase ND: Write phase file to disk
+- **Finalization task:** Explicitly states "fix ALL issues including minor ones" — model cannot rationalize skipping minor issues
+- **Plan validation as tracked task:** Must complete with zero issues before handoff
+
+**New in `writing-design-plans`:**
+- **Phase markers:** Design plans now require `<!-- START_PHASE_N -->` / `<!-- END_PHASE_N -->` markers around each implementation phase, enabling granular parsing
+
+**New in `starting-an-implementation-plan`:**
+- **Orchestration tasks:** Now tracks Branch setup, Create implementation plan, Re-read skill, Execution handoff
+- **Restore context step:** Re-reads skill before handoff to restore instructions post-compaction
+- **Terminology clarification:** Renamed "Phase 1/2/3" to descriptive names (Branch Setup, Planning, Execution Handoff) to avoid confusion with implementation plan phases
+
+**Fixed:**
+- Code reviewer step was being forgotten after compaction — now tracked as explicit Finalization task
+- Minor issues were being skipped — task text now makes fixing them mandatory
+
 ## ed3d-plan-and-execute 1.5.1
 
 Updates task tracking references for compatibility with new Claude Code task system.

--- a/plugins/ed3d-plan-and-execute/.claude-plugin/plugin.json
+++ b/plugins/ed3d-plan-and-execute/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "ed3d-plan-and-execute",
     "description": "Planning and execution workflows for Claude Code. Based on obra/superpowers.",
-    "version": "1.5.1",
+    "version": "1.6.0",
     "author": {
         "name": "Ed",
         "email": "ed@ed3d.net"

--- a/plugins/ed3d-plan-and-execute/skills/starting-an-implementation-plan/SKILL.md
+++ b/plugins/ed3d-plan-and-execute/skills/starting-an-implementation-plan/SKILL.md
@@ -31,13 +31,28 @@ If `docs/design-plans/` doesn't exist or is empty, ask the user to provide the p
 
 ## The Process
 
-This skill has three phases:
+This skill has three steps:
 
 1. **Branch Setup:** Select and create branch for implementation
 2. **Planning:** Create detailed implementation plan
 3. **Execution Handoff:** Direct user to execute the plan
 
-### Phase 1: Branch Setup
+**Step 0: Create orchestration task tracker**
+
+Use TaskCreate to track the orchestration steps:
+
+```markdown
+- [ ] Branch setup
+- [ ] Create implementation plan
+- [ ] Re-read starting-an-implementation-plan skill (restore context)
+- [ ] Execution handoff
+```
+
+The "Create implementation plan" task wraps the granular tasks created by writing-implementation-plans. The "Re-read skill" step ensures context is restored after potential compaction before handoff.
+
+### Branch Setup
+
+Mark "Branch setup" task as in_progress.
 
 Before planning, set up the branch and workspace for implementation work.
 
@@ -94,9 +109,11 @@ Options:
    - Announce: "Created and checked out branch `[branch-name]` from `origin/[main-or-master]`"
 4. **If branch creation fails:** Report error to user and ask if they want to use current branch instead
 
-**THEN proceed to Phase 2.**
+Mark "Branch setup" task as completed. **THEN proceed to Planning.**
 
-### Phase 2: Planning
+### Planning
+
+Mark "Create implementation plan" task as in_progress.
 
 **REQUIRED SUB-SKILL:** Use ed3d-plan-and-execute:writing-implementation-plans
 
@@ -111,7 +128,30 @@ The writing-implementation-plans skill will:
 
 **Output:** Complete implementation plan written to files, on appropriate branch.
 
-### Phase 3: Execution Handoff
+Mark "Create implementation plan" task as completed.
+
+### Restore Context (Before Handoff)
+
+Mark "Re-read starting-an-implementation-plan skill (restore context)" task as in_progress.
+
+**CRITICAL: Re-read this skill before proceeding to handoff.**
+
+After potentially long planning work (especially if context compaction occurred), re-read this skill file to ensure you have accurate instructions for the execution handoff:
+
+```bash
+# Re-read this skill to restore context
+cat /path/to/plugins/ed3d-plan-and-execute/skills/starting-an-implementation-plan/SKILL.md
+```
+
+Or use the Read tool on the skill file path.
+
+**Why this matters:** After compaction, you may have lost details about the handoff process. Re-reading ensures you provide correct absolute paths and instructions.
+
+Mark "Re-read starting-an-implementation-plan skill" task as completed.
+
+### Execution Handoff
+
+Mark "Execution handoff" task as in_progress.
 
 After planning is complete, hand off to execution.
 
@@ -171,6 +211,8 @@ The execute-implementation-plan command will implement the plan task-by-task wit
 - Long conversations accumulate context that degrades quality
 - /clear gives the execution phase a clean slate
 
+Mark "Execution handoff" task as completed.
+
 ## Common Mistakes
 
 | Mistake | Fix |
@@ -182,6 +224,8 @@ The execute-implementation-plan command will implement the plan task-by-task wit
 | Not verifying plan directory exists | Always `ls -d` the full plan path before outputting command |
 | Passing phase_01.md instead of directory | Pass the directory so all phases execute |
 | Forgetting to mention /clear | Always tell user to /clear before execute |
+| Skipping "Re-read skill" step before handoff | Always re-read this skill to restore context post-compaction |
+| Not creating orchestration tasks at start | Create Branch setup, Planning, Re-read, Handoff tasks in Step 0 |
 
 ## Integration with Workflow
 
@@ -192,23 +236,32 @@ Design Plan (in docs/design-plans/)
   -> User runs /start-implementation-plan with design path
 
 Starting Implementation Plan (this skill)
-  -> Phase 1: Branch Setup
-    -> Ask if user wants worktree
-    -> If yes: invoke using-git-worktrees, create at .worktrees/[friendly-name]
-    -> If no: ask which branch, create branch from main/master if needed
+  -> Step 0: Create orchestration tasks
+    -> [ ] Branch setup
+    -> [ ] Create implementation plan
+    -> [ ] Re-read skill (restore context)
+    -> [ ] Execution handoff
 
-  -> Phase 2: Planning
+  -> Branch Setup [tracked task]
+    -> Ask if user wants worktree
+    -> If yes: invoke using-git-worktrees
+    -> If no: ask which branch, create if needed
+
+  -> Planning [tracked task wrapping granular tasks]
     -> Invoke writing-implementation-plans
-    -> Detailed task planning
-    -> Phase-by-phase validation
+    -> Creates granular tasks per phase (NA, NB, NC, ND)
+    -> Creates Finalization task (code review, fix ALL issues)
     -> Write to docs/implementation-plans/
 
-  -> Phase 3: Execution Handoff
-    -> Run `git rev-parse --show-toplevel` to get absolute working root
-    -> Verify plan directory exists with `ls -d`
-    -> Output command with verified absolute paths (tell user to copy first)
+  -> Restore Context [tracked task]
+    -> Re-read this skill file
+    -> Ensures handoff instructions are accurate post-compaction
+
+  -> Execution Handoff [tracked task]
+    -> Run `git rev-parse --show-toplevel` for absolute paths
+    -> Verify plan directory exists
+    -> Output command with verified absolute paths
     -> Provide /clear command
-    -> User copies command, clears, then pastes
 
 Execute Implementation Plan (next step)
   -> Reads implementation plan
@@ -216,4 +269,4 @@ Execute Implementation Plan (next step)
   -> Code review between tasks
 ```
 
-**Purpose:** Bridge design and execution with appropriate branch isolation and context management.
+**Purpose:** Bridge design and execution with appropriate branch isolation, granular task tracking that survives compaction, and context restoration.

--- a/plugins/ed3d-plan-and-execute/skills/writing-design-plans/SKILL.md
+++ b/plugins/ed3d-plan-and-execute/skills/writing-design-plans/SKILL.md
@@ -112,8 +112,11 @@ The file is created by starting-a-design-plan Phase 3. This skill appends to tha
 
 ## Implementation Phases
 
-Break implementation into discrete phases (<=8 recommended):
+Break implementation into discrete phases (<=8 recommended).
 
+**REQUIRED: Wrap each phase in HTML comment markers:**
+
+<!-- START_PHASE_1 -->
 ### Phase 1: [Name]
 **Goal:** What this phase achieves
 
@@ -122,11 +125,16 @@ Break implementation into discrete phases (<=8 recommended):
 **Dependencies:** What must exist first
 
 **Done when:** How to verify this phase is complete (see Phase Verification below)
+<!-- END_PHASE_1 -->
 
+<!-- START_PHASE_2 -->
 ### Phase 2: [Name]
 [Same structure]
+<!-- END_PHASE_2 -->
 
 ...continue for each phase...
+
+**Why markers:** These enable writing-implementation-plans to parse phases individually, reducing context usage and enabling granular task tracking across compaction boundaries.
 
 ## Additional Considerations
 [Error handling, edge cases, future extensibility - only if relevant]
@@ -177,7 +185,8 @@ See "After Writing: Generating Summary and Glossary" below for the extraction pr
 
 Good structure (component-level):
 ```
-Phase 2: Core Services
+<!-- START_PHASE_2 -->
+### Phase 2: Core Services
 **Goal:** Token generation and session management
 
 **Components:**
@@ -188,6 +197,7 @@ Phase 2: Core Services
 **Dependencies:** Phase 1 (project setup)
 
 **Done when:** Token generation/validation works, sessions can be created/invalidated, all tests pass
+<!-- END_PHASE_2 -->
 ```
 
 Bad structure (task-level — this belongs in implementation plans):
@@ -232,6 +242,7 @@ Good Phase definitions:
 
 **Infrastructure phase example:**
 ```markdown
+<!-- START_PHASE_1 -->
 ### Phase 1: Project Setup
 **Goal:** Initialize project structure and dependencies
 
@@ -243,10 +254,12 @@ Good Phase definitions:
 **Dependencies:** None (first phase)
 
 **Done when:** `npm install` succeeds, `npm run build` succeeds
+<!-- END_PHASE_1 -->
 ```
 
 **Functionality phase example:**
 ```markdown
+<!-- START_PHASE_2 -->
 ### Phase 2: Token Generation Service
 **Goal:** JWT token generation and validation for service-to-service auth
 
@@ -257,6 +270,7 @@ Good Phase definitions:
 **Dependencies:** Phase 1 (project setup)
 
 **Done when:** Tokens can be generated, validated, and rejected when invalid/expired
+<!-- END_PHASE_2 -->
 ```
 
 Bad Phase definitions:
@@ -525,6 +539,7 @@ EOF
 | "We'll add tests after the code works" | Phase isn't done until its tests pass. Tests are deliverables, not afterthoughts. |
 | "Infrastructure needs unit tests too" | No. Infrastructure verified operationally. Don't over-engineer. |
 | "Phase 3 tests will cover Phase 2 code" | Each phase tests its own deliverables. Later phases may extend tests, but don't defer. |
+| "Phase markers are just noise" | Markers enable granular parsing. Implementation planning depends on them. Always include. |
 
 **All of these mean: STOP. Follow the structure exactly.**
 


### PR DESCRIPTION
## Summary

Addresses issues where steps were being forgotten after context compaction during implementation plan writing:
- Code reviewer step was skipped after compaction
- Minor issues not addressed during finalization

### Changes to `writing-implementation-plans`

- **Granular per-phase tasks:** Instead of one task per phase, now creates sub-tasks for each step:
  - Phase NA: Read `<!-- START_PHASE_N -->` section from design plan
  - Phase NB: Dispatch codebase-investigator to verify current state
  - Phase NC: Research external dependencies (if applicable)
  - Phase ND: Write phase file to disk
- **Finalization task:** Explicitly states "fix ALL issues including minor ones" — model cannot rationalize skipping minor issues
- **Plan validation:** Now a tracked task that must complete with zero issues before handoff

### Changes to `writing-design-plans`

- **Phase markers:** Design plans now require `<!-- START_PHASE_N -->` / `<!-- END_PHASE_N -->` markers around each implementation phase, enabling `writing-implementation-plans` to parse phases individually

### Changes to `starting-an-implementation-plan`

- **Orchestration tasks:** Now creates tracked tasks for Branch setup, Create implementation plan, Re-read skill, Execution handoff
- **Restore context step:** Re-reads the skill before handoff to restore accurate instructions post-compaction
- **Terminology fix:** Renamed "Phase 1/2/3" to descriptive names (Branch Setup, Planning, Execution Handoff) to avoid confusion with implementation plan phases

## Test plan

- [ ] Run `/start-implementation-plan` on an existing design plan
- [ ] Verify granular tasks are created per implementation phase (1A, 1B, 1C, 1D, 2A, 2B, etc.)
- [ ] Verify Finalization task text includes "including minor ones"
- [ ] Verify orchestration tasks are created (Branch setup, Create implementation plan, Re-read skill, Execution handoff)
- [ ] Simulate compaction by checking task list shows current progress