### PR TITLE
fix: remove duplicate ed3d- prefix in skill invocation command

### DIFF
--- a/plugins/ed3d-plan-and-execute/skills/starting-a-design-plan/SKILL.md
+++ b/plugins/ed3d-plan-and-execute/skills/starting-a-design-plan/SKILL.md
@@ -305,7 +305,7 @@ Ready to create the implementation plan? This requires fresh context to work eff
 
 (1) Copy this command now:
 ```
-/ed3d-ed3d-plan-and-execute:start-implementation-plan @docs/design-plans/[full-filename].md .
+/ed3d-plan-and-execute:start-implementation-plan @docs/design-plans/[full-filename].md .
 ```
 (the `.` at the end is necessary or else Claude Code will eat the command and do the wrong thing.)
 


### PR DESCRIPTION
## Summary
- Fixed typo in `starting-a-design-plan` skill where the follow-up command was `/ed3d-ed3d-plan-and-execute:start-implementation-plan` instead of `/ed3d-plan-and-execute:start-implementation-plan`

## Test plan
- [ ] Run a design plan to completion and verify the outputted command has the correct prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)