### PR TITLE
fix: sandbox-safe temp directory creation for scratchpad and cloning

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
         {
             "name": "ed3d-plan-and-execute",
             "description": "Planning and execution workflows for Claude Code. Based on obra/superpowers.",
-            "version": "1.10.3",
+            "version": "1.10.4",
             "source": "./plugins/ed3d-plan-and-execute",
             "author": {
                 "name": "Ed",
@@ -52,7 +52,7 @@
         {
             "name": "ed3d-research-agents",
             "description": "Agents used for research across multiple data sources.",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": "./plugins/ed3d-research-agents",
             "author": {
                 "name": "Ed",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## ed3d-plan-and-execute 1.10.4, ed3d-research-agents 1.0.2
+
+Fix sandbox mode compatibility for temp directory creation.
+
+**New:**
+- `creating-a-scratchpad` skill with sandbox-safe fallback chain: `mktemp -d` → `$TMPDIR` → `/tmp/claude-$UID` → `/tmp/claude-1000`
+
+**Changed:**
+- `writing-implementation-plans`: SCRATCHPAD_DIR now uses `creating-a-scratchpad` helper instead of hardcoded `/tmp/plan-*` path
+- `executing-an-implementation-plan`: SCRATCHPAD_DIR now uses `creating-a-scratchpad` helper instead of hardcoded `/tmp/exec-*` path
+- `remote-code-researcher`: clone directory now uses `creating-a-scratchpad` helper instead of bare `mktemp -d`
+
 ## ed3d-house-style 1.0.3
 
 Relax FCIS file classification to target only files with runtime behavior.

--- a/plugins/ed3d-plan-and-execute/.claude-plugin/plugin.json
+++ b/plugins/ed3d-plan-and-execute/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "ed3d-plan-and-execute",
     "description": "Planning and execution workflows for Claude Code. Based on obra/superpowers.",
-    "version": "1.10.3",
+    "version": "1.10.4",
     "author": {
         "name": "Ed",
         "email": "ed@ed3d.net"

--- a/plugins/ed3d-plan-and-execute/skills/creating-a-scratchpad/SKILL.md
+++ b/plugins/ed3d-plan-and-execute/skills/creating-a-scratchpad/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: creating-a-scratchpad
+description: Use when any skill or agent needs a session-isolated temp directory - provides a sandbox-safe fallback chain for creating scratchpad directories that works in both sandboxed and non-sandboxed Claude Code environments
+user-invocable: false
+---
+
+# Creating a Scratchpad Directory
+
+Create a session-isolated temp directory that works in sandboxed and non-sandboxed Claude Code environments.
+
+## The Helper
+
+```bash
+_make_scratchpad() {
+  local name="$1"
+  local session_id
+  session_id=$(printf '%04x%04x' $RANDOM $RANDOM)
+
+  # 1. mktemp -d: uses $TMPDIR automatically when set (sandbox-safe)
+  mktemp -d 2>/dev/null ||
+  # 2. $TMPDIR explicitly
+  { [ -n "$TMPDIR" ] && mkdir -p "${TMPDIR}/${name}-${session_id}" 2>/dev/null && echo "${TMPDIR}/${name}-${session_id}"; } ||
+  # 3. /tmp/claude-$UID (UID-based sandbox path)
+  { mkdir -p "/tmp/claude-${UID:-1000}/${name}-${session_id}" 2>/dev/null && echo "/tmp/claude-${UID:-1000}/${name}-${session_id}"; } ||
+  # 4. Last resort
+  { mkdir -p "/tmp/claude-1000/${name}-${session_id}" && echo "/tmp/claude-1000/${name}-${session_id}"; }
+}
+```
+
+## Usage
+
+Pass a descriptive name prefix. The caller is responsible for the prefix — choose something that identifies the workflow:
+
+```bash
+# In writing-implementation-plans:
+SCRATCHPAD_DIR=$(_make_scratchpad "plan-$(date +%Y-%m-%d)-${slug}")
+
+# In executing-an-implementation-plan:
+SCRATCHPAD_DIR=$(_make_scratchpad "exec-${slug}")
+
+# In remote-code-researcher:
+REPO_DIR=$(_make_scratchpad "repo-${slug}")/repo
+```
+
+## Why the Fallback Chain
+
+Claude Code sandbox mode restricts writes to specific `/tmp/claude-*` paths. The fallback chain tries the most portable option first:
+
+1. **`mktemp -d`** — most portable; automatically uses `$TMPDIR` when set, which sandbox mode sets to the allowed directory
+2. **`$TMPDIR`** — explicit fallback when `mktemp` fails but `$TMPDIR` is available
+3. **`/tmp/claude-$UID`** — sandbox allows writes here; `$UID` matches the running user
+4. **`/tmp/claude-1000`** — hardcoded last resort for UID 1000 environments
+
+## Session Isolation
+
+The `session_id` suffix (e.g., `a7f3b2`) in fallback paths (legs 2–4) ensures isolation between parallel sessions with the same name prefix and prevents collisions on retry attempts. `mktemp` (leg 1) handles this intrinsically via its random suffix.

--- a/plugins/ed3d-plan-and-execute/skills/executing-an-implementation-plan/SKILL.md
+++ b/plugins/ed3d-plan-and-execute/skills/executing-an-implementation-plan/SKILL.md
@@ -112,13 +112,12 @@ If the file exists, note its **absolute path** for use during final review. The 
 ```bash
 # Extract slug from plan directory name (last path component, without trailing slash)
 SLUG=$(basename "[plan-directory]")
-# Generate unique session ID
-SESSION_ID=$(printf '%04x%04x' $RANDOM $RANDOM)
-# Create scratchpad path
-SCRATCHPAD_DIR="/tmp/exec-${SLUG}-${SESSION_ID}"
-mkdir -p "${SCRATCHPAD_DIR}"
+# Create scratchpad using the creating-a-scratchpad skill helper
+SCRATCHPAD_DIR=$(_make_scratchpad "exec-${SLUG}")
 echo "${SCRATCHPAD_DIR}"
 ```
+
+See `ed3d-plan-and-execute:creating-a-scratchpad` for the `_make_scratchpad` helper definition. It is sandbox-safe and handles session isolation automatically.
 
 This scratchpad ensures isolation when multiple execution sessions run in parallel. Pass it to code-reviewer invocations.
 

--- a/plugins/ed3d-plan-and-execute/skills/writing-implementation-plans/SKILL.md
+++ b/plugins/ed3d-plan-and-execute/skills/writing-implementation-plans/SKILL.md
@@ -369,16 +369,14 @@ Before creating tasks, capture absolute paths:
 - `PLAN_DIR`: Absolute path to implementation plan directory (e.g., `/Users/ed/project/docs/implementation-plans/2025-01-24-feature/`)
 - `SCRATCHPAD_DIR`: Absolute path to temp directory for subagent scratch files (e.g., `/tmp/plan-2025-01-24-feature-a7f3b2/`)
 
-**Generate a unique session ID for SCRATCHPAD_DIR:**
+**Generate SCRATCHPAD_DIR using the `creating-a-scratchpad` skill:**
 
 ```bash
-SESSION_ID=$(printf '%04x%04x' $RANDOM $RANDOM)
-echo "/tmp/plan-$(date +%Y-%m-%d)-${slug}-${SESSION_ID}"
+# Use the _make_scratchpad helper from the creating-a-scratchpad skill
+SCRATCHPAD_DIR=$(_make_scratchpad "plan-$(date +%Y-%m-%d)-${slug}")
 ```
 
-The session ID (e.g., `a7f3b2`) ensures isolation between:
-- Parallel planning sessions with similar slugs
-- Retry attempts (if a plan fails and user starts over)
+See `ed3d-plan-and-execute:creating-a-scratchpad` for the full helper definition and fallback chain. The helper is sandbox-safe and ensures session isolation between parallel planning sessions and retry attempts.
 
 **SCRATCHPAD_DIR ensures session isolation.** Code reviewers and other subagents should write any temp files here, not to shared locations like `/tmp/`.
 

--- a/plugins/ed3d-research-agents/.claude-plugin/plugin.json
+++ b/plugins/ed3d-research-agents/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "ed3d-research-agents",
     "description": "Agents used for research across multiple data sources. Other plugins expect this one to be enabled.",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "author": {
         "name": "Ed",
         "email": "ed@ed3d.net"

--- a/plugins/ed3d-research-agents/agents/remote-code-researcher.md
+++ b/plugins/ed3d-research-agents/agents/remote-code-researcher.md
@@ -18,9 +18,11 @@ Answer questions by examining actual source code from external repositories.
 Execute these steps in order. Do not skip steps.
 
 1. **Find** - Web search for official repo URL
-2. **Clone** - Shallow clone to temp directory:
+2. **Clone** - Shallow clone to a sandbox-safe temp directory:
    ```bash
-   REPO_DIR=$(mktemp -d)/repo && git clone --depth 1 <url> "$REPO_DIR"
+   # Use the _make_scratchpad helper from ed3d-plan-and-execute:creating-a-scratchpad
+   REPO_DIR=$(_make_scratchpad "repo-$(date +%Y-%m-%d)")/repo
+   git clone --depth 1 <url> "$REPO_DIR"
    ```
 3. **Get commit** - Record the commit SHA: `git -C "$REPO_DIR" rev-parse HEAD`
 4. **Investigate** - Use Grep and Read on the cloned code. Find specific file paths and line numbers.


### PR DESCRIPTION
_Authored almost entirely by Claude. Please let me know if I missed something drastic_

## Fix sandbox mode compatibility for temp directory creation                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                        
  Claude Code's sandbox mode restricts filesystem writes to specific paths                                                                                                                                                                                                              
  (`$TMPDIR`, `/tmp/claude-<uid>/`). Several plugins were constructing
  scratchpad paths by hardcoding `/tmp/plan-*` and `/tmp/exec-*` prefixes,                                                                                                                                                                                                              
  which fail silently in sandboxed sessions.                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                        
  ### What changed                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                        
  Introduces a new `creating-a-scratchpad` skill in `ed3d-plan-and-execute`                                                                                                                                                                                                             
  with a sandbox-safe fallback chain:
                                                                                                                                                                                                                                                                                        
  1. `mktemp -d` — most portable; automatically uses `$TMPDIR` when set                                                                                                                                                                                                                 
  2. `$TMPDIR` — explicit fallback when `mktemp` fails                                                                                                                                                                                                                                  
  3. `/tmp/claude-$UID` — UID-based sandbox path                                                                                                                                                                                                                                        
  4. `/tmp/claude-1000` — hardcoded last resort                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                        
  Callers pass a descriptive name prefix (`plan-...`, `exec-...`, `repo-...`);                                                                                                                                                                                                          
  the skill handles uniqueness and session isolation.                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                        
  **Files updated:**                                                                                                                                                                                                                                                                    
  - `ed3d-plan-and-execute/skills/creating-a-scratchpad/SKILL.md` — new skill                                                                                                                                                                                                           
  - `ed3d-plan-and-execute/skills/writing-implementation-plans/SKILL.md` — use new skill instead of hardcoded `/tmp/plan-*`                                                                                                                                                             
  - `ed3d-plan-and-execute/skills/executing-an-implementation-plan/SKILL.md` — use new skill instead of hardcoded `/tmp/exec-*`                                                                                                                                                         
  - `ed3d-research-agents/agents/remote-code-researcher.md` — use new skill instead of bare `mktemp -d` for clone directory                                                                                                                                                             
                                                                                                                                                                                                                                                                                        
  ### Versions                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                        
  - `ed3d-plan-and-execute`: 1.10.3 → 1.10.4                                                                                                                                                                                                                                            
  - `ed3d-research-agents`: 1.0.1 → 1.0.2