### PR TITLE
feat(agents): add tool usage rules to prevent permission prompts

### DIFF
--- a/plugins/ed3d-plan-and-execute/agents/code-reviewer.md
+++ b/plugins/ed3d-plan-and-execute/agents/code-reviewer.md
@@ -221,6 +221,12 @@ After delivering review:
 - Use structured output template exactly
 - Re-verify after fixes (full cycle)
 
+## Tool Usage Rules
+
+- **Read files with the Read tool** — use `Read` with `offset` and `limit` params instead of `sed`, `cat`, `head`, or `tail`. Example: to read lines 812-983, use `Read` with `offset: 811, limit: 172`.
+- **Search files with Glob/Grep** — use `Glob` instead of `find` or `ls` for file discovery. Use `Grep` instead of `grep` or `rg`.
+- **No brace expansion in Bash** — never use `{foo,bar}` patterns in shell commands. List paths explicitly or run separate commands.
+
 ## What You MUST NOT Do
 
 - Approve without running verification commands
@@ -231,6 +237,8 @@ After delivering review:
 - Accept "should work" or "looks correct" without evidence
 - Trust agent completion reports without verification
 - Soften Critical issues to be "nice"
+- Use `sed`, `cat`, `head`, `tail` to read files (use Read tool instead)
+- Use brace expansion `{...}` in Bash commands (triggers permission prompts)
 
 ## Communication Style
 

--- a/plugins/ed3d-plan-and-execute/agents/task-bug-fixer.md
+++ b/plugins/ed3d-plan-and-execute/agents/task-bug-fixer.md
@@ -136,6 +136,12 @@ All issues addressed. Ready for code-reviewer to verify fixes.
 - Commit with clear message referencing issues
 - Provide complete report with evidence
 
+## Tool Usage Rules
+
+- **Read files with the Read tool** — use `Read` with `offset` and `limit` params instead of `sed`, `cat`, `head`, or `tail`. Example: to read lines 812-983, use `Read` with `offset: 811, limit: 172`.
+- **Search files with Glob/Grep** — use `Glob` instead of `find` or `ls` for file discovery. Use `Grep` instead of `grep` or `rg`.
+- **No brace expansion in Bash** — never use `{foo,bar}` patterns in shell commands. List paths explicitly or run separate commands.
+
 ## What You MUST NOT Do
 
 - Apply superficial fixes without understanding
@@ -144,6 +150,8 @@ All issues addressed. Ready for code-reviewer to verify fixes.
 - Report success without evidence
 - Ignore minor issues (fix everything)
 - Make unrelated changes while fixing
+- Use `sed`, `cat`, `head`, `tail` to read files (use Read tool instead)
+- Use brace expansion `{...}` in Bash commands (triggers permission prompts)
 
 ## Communication Style
 

--- a/plugins/ed3d-plan-and-execute/agents/task-implementor-fast.md
+++ b/plugins/ed3d-plan-and-execute/agents/task-implementor-fast.md
@@ -127,6 +127,12 @@ Message: [commit message]
 - Commit your work with clear message
 - Provide complete report with evidence
 
+## Tool Usage Rules
+
+- **Read files with the Read tool** — use `Read` with `offset` and `limit` params instead of `sed`, `cat`, `head`, or `tail`. Example: to read lines 812-983, use `Read` with `offset: 811, limit: 172`.
+- **Search files with Glob/Grep** — use `Glob` instead of `find` or `ls` for file discovery. Use `Grep` instead of `grep` or `rg`.
+- **No brace expansion in Bash** — never use `{foo,bar}` patterns in shell commands. List paths explicitly or run separate commands.
+
 ## What You MUST NOT Do
 
 - Start coding before reading full task
@@ -136,6 +142,8 @@ Message: [commit message]
 - Leave tests failing or build broken
 - Skip committing changes
 - Provide incomplete reports
+- Use `sed`, `cat`, `head`, `tail` to read files (use Read tool instead)
+- Use brace expansion `{...}` in Bash commands (triggers permission prompts)
 
 ## Communication Style
 


### PR DESCRIPTION
## Summary

- Adds "Tool Usage Rules" section to all three plan-and-execute agents (`task-implementor-fast`, `code-reviewer`, `task-bug-fixer`)
- Instructs agents to use `Read` with offset/limit instead of `sed`/`cat`/`head`/`tail`
- Instructs agents to use `Glob`/`Grep` instead of `find`/`ls`/`grep`
- Prohibits brace expansion `{foo,bar}` in Bash commands

## Problem

Subagents frequently use shell commands like `sed -n '812,983p' file.md` to read files and `ls src/{shows,artists}/page.tsx` with brace expansion. Both trigger Claude Code permission prompts that interrupt autonomous execution — defeating the purpose of long-running agent workflows.

## Solution

Each agent now has a "Tool Usage Rules" section with clear instructions to use Claude Code's built-in tools (`Read`, `Glob`, `Grep`) instead of shell equivalents, and explicit prohibition of brace expansion patterns. The rules are also added to each agent's "MUST NOT Do" list for reinforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)