### PR TITLE
fix: update marketplace schema

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+    "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
     "name": "ed3d-plugins",
     "version": "2.0.0",
     "description": "Unified marketplace for ed3d's Claude Code development toolkit",


### PR DESCRIPTION
`$schema` url is no longer valid

```
Unable to load schema from 'https://anthropic.com/claude-code/marketplace.schema.json': 
Not Found. The requested location could not be found.
```

this is the new one, [per](https://github.com/anthropics/claude-code/issues/9686#issuecomment-4306812924)